### PR TITLE
moved types into their own folders/packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Code
         uses: actions/checkout@v3
-      - run: go test -v
+      - run: go get . && go test -v

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="SqlDialectMappings">
-    <file url="file://$PROJECT_DIR$/cache.go" dialect="GenericSQL" />
     <file url="PROJECT" dialect="SQLite" />
   </component>
 </project>

--- a/cache/move.go
+++ b/cache/move.go
@@ -3,14 +3,13 @@ package cache
 import (
 	"database/sql"
 	"encoding/json"
+	"github.com/mazylol/pokego/types/moves"
 	"log"
-
-	"github.com/mazylol/pokego/types"
 
 	_ "github.com/mattn/go-sqlite3"
 )
 
-func AddMoveToCache(move types.Move) error {
+func AddMoveToCache(move moves.Move) error {
 	db, err := sql.Open("sqlite3", "./pokego.db")
 	if err != nil {
 		log.Fatal(err)
@@ -26,7 +25,7 @@ func AddMoveToCache(move types.Move) error {
 	return err
 }
 
-func GetMoveFromCache(name string) (types.Move, error) {
+func GetMoveFromCache(name string) (moves.Move, error) {
 	db, err := sql.Open("sqlite3", "./pokego.db")
 	if err != nil {
 		log.Fatal(err)
@@ -35,7 +34,7 @@ func GetMoveFromCache(name string) (types.Move, error) {
 		err = db.Close()
 	}(db)
 
-	var move types.Move
+	var move moves.Move
 
 	row := db.QueryRow("SELECT data FROM move WHERE name = ?", name)
 
@@ -47,7 +46,7 @@ func GetMoveFromCache(name string) (types.Move, error) {
 	return move, err
 }
 
-func AddMoveListToCache(moveList types.MoveList, count int) error {
+func AddMoveListToCache(moveList moves.MoveList, count int) error {
 	db, err := sql.Open("sqlite3", "./pokego.db")
 	if err != nil {
 		log.Fatal(err)
@@ -63,7 +62,7 @@ func AddMoveListToCache(moveList types.MoveList, count int) error {
 	return err
 }
 
-func GetMoveListFromCache(count int) (types.MoveList, error) {
+func GetMoveListFromCache(count int) (moves.MoveList, error) {
 	db, err := sql.Open("sqlite3", "./pokego.db")
 	if err != nil {
 		log.Fatal(err)
@@ -72,7 +71,7 @@ func GetMoveListFromCache(count int) (types.MoveList, error) {
 		err = db.Close()
 	}(db)
 
-	var moveList types.MoveList
+	var moveList moves.MoveList
 
 	row := db.QueryRow("SELECT data FROM move_list WHERE count = ?", count)
 

--- a/cache/pokemon.go
+++ b/cache/pokemon.go
@@ -3,14 +3,13 @@ package cache
 import (
 	"database/sql"
 	"encoding/json"
+	"github.com/mazylol/pokego/types/pokemon"
 	"log"
-
-	"github.com/mazylol/pokego/types"
 
 	_ "github.com/mattn/go-sqlite3"
 )
 
-func AddPokemonToCache(pokemon types.Pokemon) error {
+func AddPokemonToCache(pokemon pokemon.Pokemon) error {
 	db, err := sql.Open("sqlite3", "./pokego.db")
 	if err != nil {
 		log.Fatal(err)
@@ -26,7 +25,7 @@ func AddPokemonToCache(pokemon types.Pokemon) error {
 	return err
 }
 
-func GetPokemonFromCache(name string) (types.Pokemon, error) {
+func GetPokemonFromCache(name string) (pokemon.Pokemon, error) {
 	db, err := sql.Open("sqlite3", "./pokego.db")
 	if err != nil {
 		log.Fatal(err)
@@ -35,7 +34,7 @@ func GetPokemonFromCache(name string) (types.Pokemon, error) {
 		err = db.Close()
 	}(db)
 
-	var pokemon types.Pokemon
+	var pokemon pokemon.Pokemon
 
 	row := db.QueryRow("SELECT data FROM pokemon WHERE name = ?", name)
 
@@ -47,7 +46,7 @@ func GetPokemonFromCache(name string) (types.Pokemon, error) {
 	return pokemon, err
 }
 
-func AddPokemonListToCache(pokemonList types.PokemonList, count int) error {
+func AddPokemonListToCache(pokemonList pokemon.PokemonList, count int) error {
 	db, err := sql.Open("sqlite3", "./pokego.db")
 	if err != nil {
 		log.Fatal(err)
@@ -63,7 +62,7 @@ func AddPokemonListToCache(pokemonList types.PokemonList, count int) error {
 	return err
 }
 
-func GetPokemonListFromCache(count int) (types.PokemonList, error) {
+func GetPokemonListFromCache(count int) (pokemon.PokemonList, error) {
 	db, err := sql.Open("sqlite3", "./pokego.db")
 	if err != nil {
 		log.Fatal(err)
@@ -72,7 +71,7 @@ func GetPokemonListFromCache(count int) (types.PokemonList, error) {
 		err = db.Close()
 	}(db)
 
-	var pokemonList types.PokemonList
+	var pokemonList pokemon.PokemonList
 
 	row := db.QueryRow("SELECT data FROM pokemon_list WHERE count = ?", count)
 

--- a/move.go
+++ b/move.go
@@ -3,14 +3,14 @@ package pokego
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/mazylol/pokego/types/moves"
 	"log"
 
 	"github.com/mazylol/pokego/cache"
-	"github.com/mazylol/pokego/types"
 )
 
 // GetMove returns a Move struct containing information about the Move with the given name.
-func GetMove(name string) (types.Move, error) {
+func GetMove(name string) (moves.Move, error) {
 	move, err := cache.GetMoveFromCache(name)
 	if err != nil {
 		body, err := callApi(fmt.Sprintf("move/%v", name))
@@ -32,7 +32,7 @@ func GetMove(name string) (types.Move, error) {
 }
 
 // GetMoveList returns a list of Move names. You have to include a limit for the amount of names you want.
-func GetMoveList(limit int) (types.MoveList, error) {
+func GetMoveList(limit int) (moves.MoveList, error) {
 	moveList, err := cache.GetMoveListFromCache(limit)
 	if err != nil {
 		body, err := callApi(fmt.Sprintf("move?limit=%v", limit))

--- a/pokemon.go
+++ b/pokemon.go
@@ -3,14 +3,14 @@ package pokego
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/mazylol/pokego/types/pokemon"
 	"log"
 
 	"github.com/mazylol/pokego/cache"
-	"github.com/mazylol/pokego/types"
 )
 
 // GetPokemon returns a Pokemon struct containing information about the Pokemon with the given name.
-func GetPokemon(name string) (types.Pokemon, error) {
+func GetPokemon(name string) (pokemon.Pokemon, error) {
 	pokemon, err := cache.GetPokemonFromCache(name)
 	if err != nil {
 		body, err := callApi(fmt.Sprintf("pokemon/%v", name))
@@ -32,7 +32,7 @@ func GetPokemon(name string) (types.Pokemon, error) {
 }
 
 // GetPokemonList returns a list of Pokemon names. You have to include a limit for the amount of names you want.
-func GetPokemonList(limit int) (types.PokemonList, error) {
+func GetPokemonList(limit int) (pokemon.PokemonList, error) {
 	pokemonList, err := cache.GetPokemonListFromCache(limit)
 	if err != nil {
 		body, err := callApi(fmt.Sprintf("pokemon?limit=%v", limit))

--- a/types/moves/move.go
+++ b/types/moves/move.go
@@ -1,4 +1,4 @@
-package types
+package moves
 
 // Move represents a response from the PokeAPI containing information about a specific Move.
 type Move struct {

--- a/types/pokemon/pokemon.go
+++ b/types/pokemon/pokemon.go
@@ -1,4 +1,4 @@
-package types
+package pokemon
 
 // Pokemon represents a response from the PokeAPI containing information about a specific Pokemon.
 type Pokemon struct {


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request includes changes to the project structure, specifically the `types` package, and updates to the CI workflow. The `types` package has been restructured to have separate sub-packages for `pokemon` and `moves`. The CI workflow has been updated to include a `go get .` command before running tests.
> 
> ## What changed
> - The `types` package has been split into two sub-packages: `pokemon` and `moves`.
> - All references to `types.Pokemon`, `types.Move`, `types.PokemonList`, and `types.MoveList` have been updated to use the new sub-packages.
> - The CI workflow has been updated to run `go get .` before running tests. This ensures that all dependencies are fetched before tests are run.
> - Removed a redundant SQL dialect mapping from `.idea/sqldialects.xml`.
> 
> ## How to test
> To test these changes, follow these steps:
> 1. Pull the changes from this branch into your local environment.
> 2. Run `go get .` to fetch all dependencies.
> 3. Run `go test -v` to run all tests. All tests should pass.
> 4. Check the `types` package to ensure that it has been split into `pokemon` and `moves` sub-packages.
> 
> ## Why make this change
> The `types` package was becoming cluttered with different types. Splitting it into sub-packages makes the codebase more organized and easier to navigate. The update to the CI workflow ensures that all dependencies are fetched before tests are run, preventing potential errors during the CI process. The removal of the redundant SQL dialect mapping simplifies the project configuration.
</details>